### PR TITLE
Fix LD_PRELOAD environment variable in sogod.ini

### DIFF
--- a/sogod.ini
+++ b/sogod.ini
@@ -1,5 +1,5 @@
 [program:sogod]
-environment=LD_PRELOAD=/usr/lib/libytnef.so
+environment=LD_PRELOAD="/usr/lib/libytnef.so"
 command=/usr/bin/sogod -WOPidFile /var/run/sogo/sogo.pid -WONoDetach YES -WOPort 0.0.0.0:20000 -WOLogFile -
 process_name=%(program_name)s
 directory=/tmp


### PR DESCRIPTION
This pull request fixes the LD_PRELOAD environment variable in the sogod.ini file. Previously, the variable was not properly enclosed in quotes, which caused issues. This PR adds the necessary quotes to ensure the variable is set correctly.