### PR TITLE
Add memcached configuration file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN mkdir /var/spool/sogo && chown sogo:sogo /var/spool/sogo
 ADD sogod.ini /etc/supervisor.d/sogod.ini
 ADD apache.ini /etc/supervisor.d/apache.ini
 ADD cronie.ini /etc/supervisor.d/cronie.ini
+ADD memcached.ini /etc/supervisor.d/memcached.ini
 
 WORKDIR /
 CMD ["/usr/sbin/supervisord", "--nodaemon"]

--- a/memcached.ini
+++ b/memcached.ini
@@ -1,0 +1,12 @@
+[program:memcached]
+command=/usr/bin/memcached -d -u sogo
+process_name=%(program_name)s
+directory=/tmp
+startsecs=10
+autostart=true
+startretries=3
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
This commit adds a new memcached.ini configuration file with the necessary settings for running memcached as a service.