### PR TITLE
Update sogo-backup.sh path in crontab

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ ProxyPass /SOGo http://127.0.0.1:20000/SOGo retry=0 nocanon
 #   - will keep 31 days worth of backups by default
 #   - runs once a day by default, but can run more frequently
 #   - make sure to set the path to sogo-backup.sh correctly
-30 0 * * * sogo /usr/share/doc/sogo-*/sogo-backup.sh
+30 0 * * * sogo /usr/lib/sogo/scripts/sogo-backup.sh
 ```
 
 


### PR DESCRIPTION
This pull request updates the path to the sogo-backup.sh script in the crontab file. The previous path was incorrect, and this change ensures that the correct path is used for the backup script.